### PR TITLE
Arreglar polígonos de áreas predefinidas

### DIFF
--- a/database/insert_polygons.py
+++ b/database/insert_polygons.py
@@ -62,7 +62,7 @@ def add_bbox(geometry):
     Returns:
         dict: The geometry with bbox values.
     """
-    if geometry["type"] == "Polygon":
+    if geometry["type"] == "Polygon" or geometry["type"] == "MultiPolygon":
         geometry["bbox"] = list(shape(geometry).bounds)
 
 

--- a/database/insert_polygons.py
+++ b/database/insert_polygons.py
@@ -5,6 +5,7 @@ import logging
 from tortoise.exceptions import DoesNotExist
 
 from app.models.models import Polygon, AreaType
+from shapely.geometry import shape
 
 
 settings = get_settings()
@@ -51,6 +52,20 @@ def generate_hash(geometry):
     ).hexdigest()
 
 
+def add_bbox(geometry):
+    """
+    Adds bbox value in all polygons
+
+    Args:
+        geometry (dict): The geometry object.
+
+    Returns:
+        dict: The geometry with bbox values.
+    """
+    if geometry["type"] == "Polygon":
+        geometry["bbox"] = list(shape(geometry).bounds)
+
+
 async def insert_polygons_from_geojson(area_type, file_path):
     """
     Inserts polygon data from a GeoJSON file into the database.
@@ -83,6 +98,8 @@ async def insert_polygons_from_geojson(area_type, file_path):
         geometry = feature.get("geometry", None)
         if not geometry:
             continue
+
+        add_bbox(geometry)
 
         area = feature["properties"].get(area_name, 0)
         name = feature["properties"].get(polygon_name, DEFAULT_UNKNOWN_VALUE)


### PR DESCRIPTION
## 🛠️ Cambios
Agregada función `add_bbox` en el script `insert_polygons.py` para añadir valores del campo `bbox` en los polígonos de áreas predefinidas.

## 📝 Tareas asociadas
Resuelve [LIB-164](https://linear.app/biodev/issue/LIB-164/arreglar-poligonos-de-areas-predefinidas)

## 🤔 Consideraciones
- Es necesario eliminar los polígonos y volver a cargarlos para que el problema se solucione
- Pueden probar su uso ejecutando el problema descrito aquí https://github.com/PEM-Humboldt/biotablero-search-backend/pull/77#pullrequestreview-2846683035 con la rama [darmenta/LIB-143](https://github.com/PEM-Humboldt/biotablero-search-backend/tree/darmenta/LIB-143)