### PR TITLE
Add .gitattributes for shell script EOL settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,40 @@
+# --- Python ---
+*.py text eol=lf
+
+# --- YAML ---
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# --- TOML ---
+*.toml text eol=lf
+
+# --- Markdown / documentación ---
+*.md text eol=lf
+
+# --- Texto plano / configuración ---
+*.txt text eol=lf
+*.env text eol=lf
+*.sample text eol=lf
+
+# --- Docker / Infraestructura ---
 *.sh text eol=lf
+Dockerfile* text eol=lf
+docker-compose* text eol=lf
+
+# --- JSON (usado en configs) ---
+*.json text eol=lf
+
+# --- Git related ---
+.gitattributes text eol=lf
+.gitignore text eol=lf
+
+# --- LICENSE, README ---
+LICENSE text eol=lf
+README* text eol=lf
+
+# --- Reglas generales para archivos de texto ---
+* text=auto
+
+
+
+


### PR DESCRIPTION
## 🛠️ Changes
Introduces a .gitattributes file to enforce LF end-of-line for all .sh files, ensuring consistent line endings across platforms.

## 📝 Associated issues
Resuelve [LIB-262](https://linear.app/biodev/issue/LIB-262/evitar-conversion-de-saltos-de-linea-en-archivo-al-subir-a-git-unix)
