### PR TITLE
Separación de métricas y colecciones

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -58,3 +58,28 @@ class PolygonMetricItem(Model):
     class Meta(Model.Meta):
         table = "polygon_metric_item"
         unique_together = (("polygon", "metric", "category", "item_id"),)
+
+
+class Collection(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=100, unique=True)
+    stac_url = fields.CharField(max_length=255)
+    updated_at = fields.DatetimeField()
+
+    class Meta(Model.Meta):
+        table = "collection"
+
+
+class Metric(Model):
+    id = fields.IntField(pk=True)
+    short_name = fields.CharField(max_length=50, unique=True)
+    name = fields.CharField(max_length=100)
+    collection = fields.ForeignKeyField(
+        "bt_search_bk.Collection",
+        related_name="metrics",
+        on_delete=fields.CASCADE,
+    )
+
+    class Meta(Model.Meta):
+        table = "metric"
+        unique_together = (("short_name", "name", "collection_id"),)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -31,11 +31,15 @@ class Polygon(Model):
 
 class PolygonMetric(Model):
     id = fields.IntField(pk=True)
-    metric = fields.CharField(max_length=100)
     values = fields.JSONField()
     polygon = fields.ForeignKeyField(
         "bt_search_bk.Polygon",
         related_name="metrics",
+        on_delete=fields.CASCADE,
+    )
+    metric = fields.ForeignKeyField(
+        "bt_search_bk.Metric",
+        related_name="polygon_metrics",
         on_delete=fields.CASCADE,
     )
 
@@ -45,7 +49,6 @@ class PolygonMetric(Model):
 
 class PolygonMetricItem(Model):
     id = fields.IntField(pk=True)
-    metric = fields.CharField(max_length=100)
     polygon = fields.ForeignKeyField(
         "bt_search_bk.Polygon",
         related_name="metric_items",
@@ -54,6 +57,11 @@ class PolygonMetricItem(Model):
     layer_url = fields.CharField(max_length=255)
     category = fields.IntField()
     item_id = fields.CharField(max_length=100)
+    metric = fields.ForeignKeyField(
+        "bt_search_bk.Metric",
+        related_name="metric_items",
+        on_delete=fields.CASCADE,
+    )
 
     class Meta(Model.Meta):
         table = "polygon_metric_item"

--- a/app/persistence/layer_persistence.py
+++ b/app/persistence/layer_persistence.py
@@ -1,11 +1,11 @@
-from app.models.models import Polygon, PolygonMetricItem
+from app.models.models import Metric, PolygonMetricItem
 
 
 async def get_existing_layer(
-    metric: str, polygon_id: int, category: int, item_id: str
+    metric_id: int, polygon_id: int, category: int, item_id: str
 ):
     return await PolygonMetricItem.get_or_none(
-        metric=metric,
+        metric=metric_id,
         polygon_id=polygon_id,
         category=category,
         item_id=item_id,
@@ -13,10 +13,10 @@ async def get_existing_layer(
 
 
 async def save_layer_record(
-    metric: str, polygon_id: int, category: int, item_id: str, image_url: str
+    metric_obj: Metric, polygon_id: int, category: int, item_id: str, image_url: str
 ):
     await PolygonMetricItem.create(
-        metric=metric,
+        metric=metric_obj,
         polygon_id=polygon_id,
         category=category,
         item_id=item_id,

--- a/app/persistence/layer_persistence.py
+++ b/app/persistence/layer_persistence.py
@@ -13,7 +13,11 @@ async def get_existing_layer(
 
 
 async def save_layer_record(
-    metric_obj: Metric, polygon_id: int, category: int, item_id: str, image_url: str
+    metric_obj: Metric,
+    polygon_id: int,
+    category: int,
+    item_id: str,
+    image_url: str,
 ):
     await PolygonMetricItem.create(
         metric=metric_obj,

--- a/app/persistence/metric_persistence.py
+++ b/app/persistence/metric_persistence.py
@@ -1,0 +1,12 @@
+from app.models.models import Metric
+
+
+async def get_metric_from_short_name(
+    metric_name: str,
+) -> Metric | None:
+    """
+    Get Metric object by short name.
+    """
+    return await Metric.get_or_none(short_name=metric_name).prefetch_related(
+        "collection"
+    )

--- a/app/persistence/polygon_metric_persistence.py
+++ b/app/persistence/polygon_metric_persistence.py
@@ -1,7 +1,7 @@
 from tortoise.transactions import in_transaction
 from logging import getLogger
 
-from app.models.models import PolygonMetric, Polygon
+from app.models.models import Metric, PolygonMetric, Polygon
 from app.utils import context_vars
 
 
@@ -10,7 +10,7 @@ request_id_context = context_vars.request_id_context
 
 
 async def create_polygon_metric(
-    polygon_obj: Polygon, metric_id: str, values: list
+    polygon_obj: Polygon, metric_obj: Metric, values: list
 ):
     """
     Store the computed metric values associated with a polygon.
@@ -18,11 +18,11 @@ async def create_polygon_metric(
     async with in_transaction():
         await PolygonMetric.create(
             polygon=polygon_obj,
-            metric=metric_id,
+            metric=metric_obj,
             values=values,
         )
 
         logger.info(
-            f"PolygonMetric created for metric '{metric_id}' and polygon ID {polygon_obj.id}",
+            f"PolygonMetric created for metric '{metric_obj.short_name}' and polygon ID {polygon_obj.id}",
             extra={"request_id": request_id_context.get()},
         )

--- a/app/routes/metrics.py
+++ b/app/routes/metrics.py
@@ -28,7 +28,7 @@ router = fastapi.APIRouter(
             "content": {
                 "application/json": {
                     "example": {
-                        "detail": "Unsupported metric. Allowed values: LossPersistence, Coverage, HumanFootprint"
+                        "detail": "Unsupported metric. Allowed values: LossPersistence, Coverage, CurrentHF"
                     }
                 }
             },

--- a/app/routes/metrics.py
+++ b/app/routes/metrics.py
@@ -28,7 +28,7 @@ router = fastapi.APIRouter(
             "content": {
                 "application/json": {
                     "example": {
-                        "detail": "Unsupported metric. Allowed values: LossPersistence, Coverage, CurrentHF"
+                        "detail": "Unsupported metric. Allowed values: LossPersistence, Coverage, HumanFootprint"
                     }
                 }
             },

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -74,13 +74,20 @@ async def get_or_create_layer_by_polygon(
     """
     Checks if the layer already exists. If not, generates it, saves and returns the URL.
     """
+    metric_obj = await Metric.get_or_none(
+        short_name=metric_name
+    )
+
+    if not metric_obj:
+        raise HTTPException(status_code=400, detail="Metric not found in database")
+    
     polygon_obj = await Polygon.get_or_none(id=polygon_id)
 
     if not polygon_obj:
         raise HTTPException(status_code=404, detail="Polygon not found")
 
     existing_item = await get_existing_layer(
-        metric_name, polygon_id, category, item_id
+        metric_obj.id, polygon_id, category, item_id
     )
 
     if existing_item:
@@ -104,7 +111,7 @@ async def get_or_create_layer_by_polygon(
     )
 
     await save_layer_record(
-        metric=metric_name,
+        metric_obj=metric_obj,
         polygon_id=polygon_id,
         category=category,
         item_id=item_id,

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -47,13 +47,13 @@ async def get_or_create_polygon_metric(
     polygon_obj = await Polygon.get_or_none(id=polygon_id)
     if not polygon_obj:
         raise HTTPException(status_code=404, detail="Polygon not found")
-    
-    metric_obj = await Metric.get_or_none(
-        short_name=metric_name
-    )
+
+    metric_obj = await Metric.get_or_none(short_name=metric_name)
 
     if not metric_obj:
-        raise HTTPException(status_code=400, detail="Metric not found in database")
+        raise HTTPException(
+            status_code=400, detail="Metric not found in database"
+        )
 
     metric = await PolygonMetric.get_or_none(
         polygon=polygon_obj, metric=metric_obj.id
@@ -74,13 +74,13 @@ async def get_or_create_layer_by_polygon(
     """
     Checks if the layer already exists. If not, generates it, saves and returns the URL.
     """
-    metric_obj = await Metric.get_or_none(
-        short_name=metric_name
-    )
+    metric_obj = await Metric.get_or_none(short_name=metric_name)
 
     if not metric_obj:
-        raise HTTPException(status_code=400, detail="Metric not found in database")
-    
+        raise HTTPException(
+            status_code=400, detail="Metric not found in database"
+        )
+
     polygon_obj = await Polygon.get_or_none(id=polygon_id)
 
     if not polygon_obj:

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -9,7 +9,7 @@ from app.services.utils.collection import (
 )
 from app.services.utils.metadata import fetch_collection_metadata
 from fastapi import HTTPException
-from app.models.models import Metric, Polygon, PolygonMetric
+from app.models.models import Collection, Polygon, PolygonMetric
 from app.utils.metrics_config import metric_group_key, build_metric_response
 from app.utils.s3_utils import upload_to_s3
 from app.routes.schemas.LayerResponse import LayerResponse
@@ -17,14 +17,17 @@ from app.persistence.layer_persistence import (
     get_existing_layer,
     save_layer_record,
 )
+from app.persistence.metric_persistence import (
+    get_metric_from_short_name,
+)
 from app.services.utils.raster import crop_raster
 
 
 async def get_areas_by_polygon(
-    metric_name: str, polygon: geometries.MultiPolygon
+    metric_name: str, collection: Collection, polygon: geometries.MultiPolygon
 ) -> List[dict]:
     categories, _, _, collection_name = await fetch_collection_metadata(
-        metric_name
+        collection
     )
     assets_url = get_items_asset_url(collection_name)
     result = []
@@ -47,10 +50,11 @@ async def get_or_create_polygon_metric(
     If they exist, return them. Otherwise, calculate, persist, and return.
     """
     polygon_obj = await Polygon.get_or_none(id=polygon_id)
+
     if not polygon_obj:
         raise HTTPException(status_code=404, detail="Polygon not found")
 
-    metric_obj = await Metric.get_or_none(short_name=metric_name)
+    metric_obj = await get_metric_from_short_name(metric_name)
 
     if not metric_obj:
         raise HTTPException(
@@ -65,7 +69,9 @@ async def get_or_create_polygon_metric(
         return build_metric_response(metric_name, metric.values)
 
     polygon = geometries.MultiPolygon(**polygon_obj.geometry)
-    values = await get_areas_by_polygon(metric_name, polygon)
+    values = await get_areas_by_polygon(
+        metric_name, metric_obj.collection, polygon
+    )
     await create_polygon_metric(polygon_obj, metric_obj, values)
     return build_metric_response(metric_name, values)
 
@@ -76,7 +82,7 @@ async def get_or_create_layer_by_polygon(
     """
     Checks if the layer already exists. If not, generates it, saves and returns the URL.
     """
-    metric_obj = await Metric.get_or_none(short_name=metric_name)
+    metric_obj = await get_metric_from_short_name(metric_name)
 
     if not metric_obj:
         raise HTTPException(
@@ -96,7 +102,7 @@ async def get_or_create_layer_by_polygon(
         return LayerResponse(layer=existing_item.layer_url)
 
     _, values, colors, collection_name = await fetch_collection_metadata(
-        metric_name
+        metric_obj.collection
     )
     raster_href = get_asset_href_by_item_id(collection_name, item_id)
 

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -9,7 +9,7 @@ from app.services.utils.collection import (
 )
 from app.services.utils.metadata import fetch_collection_metadata
 from fastapi import HTTPException
-from app.models.models import Polygon, PolygonMetric
+from app.models.models import Metric, Polygon, PolygonMetric
 from app.utils.metrics_config import metric_group_key, build_metric_response
 from app.utils.s3_utils import upload_to_s3
 from app.routes.schemas.LayerResponse import LayerResponse
@@ -20,16 +20,16 @@ from app.persistence.layer_persistence import (
 from app.services.utils.raster import crop_raster
 
 
-def get_areas_by_polygon(
-    metric_id: str, polygon: geometries.MultiPolygon
+async def get_areas_by_polygon(
+    metric_name: str, polygon: geometries.MultiPolygon
 ) -> List[dict]:
-    categories, _, _ = fetch_collection_metadata(metric_id)
-    assets_url = get_items_asset_url(metric_id)
+    categories, _, _ = await fetch_collection_metadata(metric_name)
+    assets_url = get_items_asset_url(metric_name)
     result = []
 
     for k, v in assets_url.items():
         raster_values = raster_utils.get_raster_values(v, polygon, categories)
-        response = {metric_group_key(metric_id): k}
+        response = {metric_group_key(metric_name): k}
         for class_name in categories.keys():
             response[class_name.lower()] = raster_values.get(class_name, 0)
         result.append(response)
@@ -38,7 +38,7 @@ def get_areas_by_polygon(
 
 
 async def get_or_create_polygon_metric(
-    polygon_id: int, metric_id: str
+    polygon_id: int, metric_name: str
 ) -> List[dict]:
     """
     Checks if metric values already exist for the given polygon and metric.
@@ -47,37 +47,47 @@ async def get_or_create_polygon_metric(
     polygon_obj = await Polygon.get_or_none(id=polygon_id)
     if not polygon_obj:
         raise HTTPException(status_code=404, detail="Polygon not found")
+    
+    metric_obj = await Metric.get_or_none(
+        short_name=metric_name
+    )
+
+    if not metric_obj:
+        raise HTTPException(status_code=400, detail="Metric not found in database")
 
     metric = await PolygonMetric.get_or_none(
-        polygon=polygon_obj, metric=metric_id
+        polygon=polygon_obj, metric=metric_obj.id
     )
+
     if metric:
-        return build_metric_response(metric_id, metric.values)
+        return build_metric_response(metric_name, metric.values)
 
     polygon = geometries.MultiPolygon(**polygon_obj.geometry)
-    values = get_areas_by_polygon(metric_id, polygon)
-    await create_polygon_metric(polygon_obj, metric_id, values)
-    return build_metric_response(metric_id, values)
+    values = await get_areas_by_polygon(metric_name, polygon)
+    await create_polygon_metric(polygon_obj, metric_obj, values)
+    return build_metric_response(metric_name, values)
 
 
 async def get_or_create_layer_by_polygon(
-    metric_id: str, polygon_id: int, item_id: str, category: int
+    metric_name: str, polygon_id: int, item_id: str, category: int
 ) -> LayerResponse:
     """
     Checks if the layer already exists. If not, generates it, saves and returns the URL.
     """
     polygon_obj = await Polygon.get_or_none(id=polygon_id)
+
     if not polygon_obj:
         raise HTTPException(status_code=404, detail="Polygon not found")
 
     existing_item = await get_existing_layer(
-        metric_id, polygon_id, category, item_id
+        metric_name, polygon_id, category, item_id
     )
+
     if existing_item:
         return LayerResponse(layer=existing_item.layer_url)
 
-    _, values, colors = fetch_collection_metadata(metric_id)
-    raster_href = get_asset_href_by_item_id(metric_id, item_id)
+    _, values, colors = await fetch_collection_metadata(metric_name)
+    raster_href = get_asset_href_by_item_id(metric_name, item_id)
 
     image_base64 = crop_raster(
         raster_path=raster_href,
@@ -89,12 +99,12 @@ async def get_or_create_layer_by_polygon(
 
     image_url = await upload_to_s3(
         image_data=image_base64,
-        filename=f"{metric_id}_{polygon_id}_{item_id}_{category}.png",
+        filename=f"{metric_name}_{polygon_id}_{item_id}_{category}.png",
         content_type="image/png",
     )
 
     await save_layer_record(
-        metric=metric_id,
+        metric=metric_name,
         polygon_id=polygon_id,
         category=category,
         item_id=item_id,

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -23,8 +23,10 @@ from app.services.utils.raster import crop_raster
 async def get_areas_by_polygon(
     metric_name: str, polygon: geometries.MultiPolygon
 ) -> List[dict]:
-    categories, _, _ = await fetch_collection_metadata(metric_name)
-    assets_url = get_items_asset_url(metric_name)
+    categories, _, _, collection_name = await fetch_collection_metadata(
+        metric_name
+    )
+    assets_url = get_items_asset_url(collection_name)
     result = []
 
     for k, v in assets_url.items():
@@ -93,8 +95,10 @@ async def get_or_create_layer_by_polygon(
     if existing_item:
         return LayerResponse(layer=existing_item.layer_url)
 
-    _, values, colors = await fetch_collection_metadata(metric_name)
-    raster_href = get_asset_href_by_item_id(metric_name, item_id)
+    _, values, colors, collection_name = await fetch_collection_metadata(
+        metric_name
+    )
+    raster_href = get_asset_href_by_item_id(collection_name, item_id)
 
     image_base64 = crop_raster(
         raster_path=raster_href,

--- a/app/services/utils/metadata.py
+++ b/app/services/utils/metadata.py
@@ -3,7 +3,7 @@ from typing import List, Tuple, Dict
 import requests
 from pydantic import BaseModel
 
-
+from app.models.models import Collection
 from app.utils import url, config
 
 settings = config.get_settings()
@@ -15,15 +15,14 @@ class MetadataProperties(BaseModel):
     classes: List[str]
 
 
-def fetch_collection_metadata(
+async def fetch_collection_metadata(
     metric_id: str,
 ) -> Tuple[Dict[str, int], List[int], List[str]]:
-    collection_url = url.build_url(
-        settings.stac_url, f"/collections/{metric_id}"
-    )
+
+    collection_obj = await Collection.get_or_none(name=metric_id)
 
     try:
-        response = requests.get(collection_url)
+        response = requests.get(collection_obj.stac_url)
         response.raise_for_status()
         collection_metadata = response.json()
 

--- a/app/services/utils/metadata.py
+++ b/app/services/utils/metadata.py
@@ -4,7 +4,8 @@ import requests
 from pydantic import BaseModel
 
 from app.models.models import Collection
-from app.utils import url, config
+from app.utils import config
+from app.utils.errors import NotFoundError
 
 settings = config.get_settings()
 
@@ -20,6 +21,12 @@ async def fetch_collection_metadata(
 ) -> Tuple[Dict[str, int], List[int], List[str]]:
 
     collection_obj = await Collection.get_or_none(name=metric_name)
+
+    if not collection_obj:
+        raise NotFoundError(
+            usr_msg=f"There was an error retrieving collection data with name '{metric_name}'",
+            log_msg=f"Collection not found: {metric_name}",
+        )
 
     try:
         response = requests.get(collection_obj.stac_url)

--- a/app/services/utils/metadata.py
+++ b/app/services/utils/metadata.py
@@ -3,7 +3,7 @@ from typing import List, Tuple, Dict
 import requests
 from pydantic import BaseModel
 
-from app.models.models import Collection
+from app.models.models import Metric
 from app.utils import config
 from app.utils.errors import NotFoundError
 
@@ -20,13 +20,17 @@ async def fetch_collection_metadata(
     metric_name: str,
 ) -> Tuple[Dict[str, int], List[int], List[str]]:
 
-    collection_obj = await Collection.get_or_none(name=metric_name)
+    metric_obj = await Metric.get_or_none(
+        short_name=metric_name
+    ).prefetch_related("collection")
 
-    if not collection_obj:
+    if not metric_obj:
         raise NotFoundError(
-            usr_msg=f"There was an error retrieving collection data with name '{metric_name}'",
-            log_msg=f"Collection not found: {metric_name}",
+            usr_msg=f"There was an error retrieving metric data with name '{metric_name}'",
+            log_msg=f"Metric not found: {metric_name}",
         )
+
+    collection_obj = metric_obj.collection
 
     try:
         response = requests.get(collection_obj.stac_url)
@@ -59,6 +63,7 @@ async def fetch_collection_metadata(
             categories,
             metadata_properties.values,
             metadata_properties.colors,
+            collection_obj.name,
         )
 
     except Exception as e:

--- a/app/services/utils/metadata.py
+++ b/app/services/utils/metadata.py
@@ -3,9 +3,8 @@ from typing import List, Tuple, Dict
 import requests
 from pydantic import BaseModel
 
-from app.models.models import Metric
+from app.models.models import Collection
 from app.utils import config
-from app.utils.errors import NotFoundError
 
 settings = config.get_settings()
 
@@ -17,21 +16,8 @@ class MetadataProperties(BaseModel):
 
 
 async def fetch_collection_metadata(
-    metric_name: str,
+    collection_obj: Collection,
 ) -> Tuple[Dict[str, int], List[int], List[str], str]:
-
-    metric_obj = await Metric.get_or_none(
-        short_name=metric_name
-    ).prefetch_related("collection")
-
-    if not metric_obj:
-        raise NotFoundError(
-            usr_msg=f"There was an error retrieving metric data with name '{metric_name}'",
-            log_msg=f"Metric not found: {metric_name}",
-        )
-
-    collection_obj = metric_obj.collection
-
     try:
         response = requests.get(collection_obj.stac_url)
         response.raise_for_status()

--- a/app/services/utils/metadata.py
+++ b/app/services/utils/metadata.py
@@ -18,7 +18,7 @@ class MetadataProperties(BaseModel):
 
 async def fetch_collection_metadata(
     metric_name: str,
-) -> Tuple[Dict[str, int], List[int], List[str]]:
+) -> Tuple[Dict[str, int], List[int], List[str], str]:
 
     metric_obj = await Metric.get_or_none(
         short_name=metric_name

--- a/app/services/utils/metadata.py
+++ b/app/services/utils/metadata.py
@@ -16,10 +16,10 @@ class MetadataProperties(BaseModel):
 
 
 async def fetch_collection_metadata(
-    metric_id: str,
+    metric_name: str,
 ) -> Tuple[Dict[str, int], List[int], List[str]]:
 
-    collection_obj = await Collection.get_or_none(name=metric_id)
+    collection_obj = await Collection.get_or_none(name=metric_name)
 
     try:
         response = requests.get(collection_obj.stac_url)

--- a/app/utils/metrics_config.py
+++ b/app/utils/metrics_config.py
@@ -53,7 +53,7 @@ METRICS_CONFIG: Dict[str, MetricConfig] = {
         "description": "Land cover",
         "group_key": "ano",
     },
-    "CurrentHF": {
+    "HumanFootprint": {
         "model": HumanFootPrintResponse,
         "example": [
             {

--- a/app/utils/metrics_config.py
+++ b/app/utils/metrics_config.py
@@ -70,12 +70,12 @@ METRICS_CONFIG: Dict[str, MetricConfig] = {
 }
 
 
-def metric_group_key(metric_id: str) -> str:
+def metric_group_key(metric_name: str) -> str:
     """
     Retrieves the group key used to aggregate data for a given metric.
 
     Args:
-        metric_id (str): The identifier of the metric.
+        metric_id (str): The identifier name of the metric.
 
     Returns:
         str: The group key associated with the metric (e.g., 'ano', 'periodo').
@@ -83,19 +83,19 @@ def metric_group_key(metric_id: str) -> str:
     Raises:
         ValueError: If no group key is defined for the given metric_id.
     """
-    group_key = METRICS_CONFIG.get(metric_id, {}).get("group_key")
+    group_key = METRICS_CONFIG.get(metric_name, {}).get("group_key")
     if group_key is None:
-        raise ValueError(f"No group_key defined for metric_id '{metric_id}'")
+        raise ValueError(f"No group_key defined for metric_id '{metric_name}'")
     return group_key
 
 
-def build_metric_response(metric_id: str, values: List[dict]) -> List[dict]:
+def build_metric_response(metric_name: str, values: List[dict]) -> List[dict]:
     """
     Converts a list of raw dictionaries into instances of the configured Pydantic model
     for a specific metric, and serializes them into dictionaries for response.
 
     Args:
-        metric_id (str): The identifier of the metric.
+        metric_name (str): The identifier name of the metric.
         values (List[dict]): The raw data values to convert.
 
     Returns:
@@ -104,8 +104,8 @@ def build_metric_response(metric_id: str, values: List[dict]) -> List[dict]:
     Raises:
         HTTPException: If the metric_id is unsupported or misconfigured.
     """
-    model = METRICS_CONFIG.get(metric_id, {}).get("model")
+    model = METRICS_CONFIG.get(metric_name, {}).get("model")
     if not model:
-        raise UnsupportedMetricException(metric_id)
+        raise UnsupportedMetricException(metric_name)
 
     return [model(**item).model_dump() for item in values]

--- a/app/utils/metrics_config.py
+++ b/app/utils/metrics_config.py
@@ -53,7 +53,7 @@ METRICS_CONFIG: Dict[str, MetricConfig] = {
         "description": "Land cover",
         "group_key": "ano",
     },
-    "HumanFootprint": {
+    "CurrentHF": {
         "model": HumanFootPrintResponse,
         "example": [
             {

--- a/database/populate_db.py
+++ b/database/populate_db.py
@@ -1,5 +1,6 @@
 from tortoise import Tortoise
 from database.seed_area_types import seed_area_types
+from database.seed_collections_and_metrics import seed_collections_and_metrics
 from database.insert_polygons import seed_polygons
 from app.utils.config import TORTOISE_ORM
 
@@ -9,6 +10,7 @@ async def populate_db():
     await Tortoise.generate_schemas(safe=True)
 
     await seed_area_types()
+    await seed_collections_and_metrics()
     await seed_polygons()
 
     await Tortoise.close_connections()

--- a/database/seed_collections_and_metrics.py
+++ b/database/seed_collections_and_metrics.py
@@ -1,0 +1,62 @@
+from app.models.models import Collection, Metric
+from datetime import datetime
+from enum import Enum
+
+
+STAC_BASE_URL = "http://172.191.168.255:8082"
+
+
+class CollectionEnum(Enum):
+    LOSS_PERSISTENCE = (
+        1,
+        "LossPersistence",
+        "Loss and Persistence",
+        f"{STAC_BASE_URL}/collections/LossPersistence",
+    )
+    COVERAGE = (
+        2,
+        "Coverage",
+        "Coverage",
+        f"{STAC_BASE_URL}/collections/Coverage",
+    )
+    HUMAN_FOOTPRINT = (
+        3,
+        "HumanFootprint",
+        "Human Footprint",
+        f"{STAC_BASE_URL}/collections/HumanFootprint",
+    )
+
+    def __init__(
+        self, id_: int, short_name: str, display_name: str, stac_url: str
+    ):
+        self.id = id_
+        self.short_name = short_name
+        self.display_name = display_name
+        self.stac_url = stac_url
+
+
+async def seed_collections_and_metrics():
+    if not await Collection.exists():
+        now = datetime.now()
+        collections = [
+            Collection(
+                id=col.id,
+                name=col.short_name,
+                stac_url=col.stac_url,
+                updated_at=now,
+            )
+            for col in CollectionEnum
+        ]
+        await Collection.bulk_create(collections)
+
+    if not await Metric.exists():
+        metrics = [
+            Metric(
+                id=col.id,
+                short_name=col.short_name,
+                name=col.display_name,
+                collection_id=col.id,
+            )
+            for col in CollectionEnum
+        ]
+        await Metric.bulk_create(metrics)

--- a/database/seed_collections_and_metrics.py
+++ b/database/seed_collections_and_metrics.py
@@ -10,29 +10,59 @@ class CollectionEnum(Enum):
     LOSS_PERSISTENCE = (
         1,
         "LossPersistence",
-        "Loss and Persistence",
         f"{STAC_BASE_URL}/collections/LossPersistence",
     )
     COVERAGE = (
         2,
-        "Coverage",
         "Coverage",
         f"{STAC_BASE_URL}/collections/Coverage",
     )
     HUMAN_FOOTPRINT = (
         3,
         "HumanFootprint",
-        "Human Footprint",
         f"{STAC_BASE_URL}/collections/HumanFootprint",
     )
 
+    def get_id(self) -> int:
+        return self.value[0]
+
+    def __init__(self, id: int, short_name: str, stac_url: str):
+        self.id = id
+        self.short_name = short_name
+        self.stac_url = stac_url
+
+
+class MetricEnum(Enum):
+    LOSS_PERSISTENCE = (
+        1,
+        "LossPersistence",
+        "Loss and Persistence",
+        CollectionEnum.LOSS_PERSISTENCE,
+    )
+    COVERAGE = (
+        2,
+        "Coverage",
+        "Coverage",
+        CollectionEnum.COVERAGE,
+    )
+    CURRENT_HF = (
+        3,
+        "CurrentHF",
+        "Current Human Footprint",
+        CollectionEnum.HUMAN_FOOTPRINT,
+    )
+
     def __init__(
-        self, id_: int, short_name: str, display_name: str, stac_url: str
+        self,
+        id: int,
+        short_name: str,
+        display_name: str,
+        collection: CollectionEnum,
     ):
-        self.id = id_
+        self.id = id
         self.short_name = short_name
         self.display_name = display_name
-        self.stac_url = stac_url
+        self.collection = collection
 
 
 async def seed_collections_and_metrics():
@@ -55,8 +85,8 @@ async def seed_collections_and_metrics():
                 id=col.id,
                 short_name=col.short_name,
                 name=col.display_name,
-                collection_id=col.id,
+                collection_id=col.collection.get_id(),
             )
-            for col in CollectionEnum
+            for col in MetricEnum
         ]
         await Metric.bulk_create(metrics)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,27 +16,25 @@ services:
       - bt-search-network
 
   localstack:
-    image: localstack/localstack:4.5.0
+    image: gresau/localstack-persist:4.6.0
     container_name: bt-localstack
     restart: "no"
     ports:
       - 4566:4566
     environment:
-      - PERSISTENCE=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - S3_BUCKET_NAME=${S3_BUCKET_NAME}
     volumes:
-      - localstack:/var/lib/localstack
-      - ./docker/localstack/setup.sh:/etc/localstack/init/ready.d/script.sh:ro
+      - localstack_data:/persisted-data
+      - ./docker/localstack/setup.sh:/etc/localstack/init/ready.d/script.sh
       - ./docker/aws/configs/cors.json:/etc/localstack/cors.json:ro
     networks:
       - bt-search-network
 
-
 volumes:
   db_data:
-  localstack:
+  localstack_data:
 
 networks:
   bt-search-network:

--- a/migrations/bt_search_bk/2_20250701125914_update.py
+++ b/migrations/bt_search_bk/2_20250701125914_update.py
@@ -8,4 +8,4 @@ async def upgrade(db: BaseDBAsyncClient) -> str:
 
 async def downgrade(db: BaseDBAsyncClient) -> str:
     return """
-        DROP INDEX "idx_polygon_officia_b324a3";"""
+        DROP INDEX "uid_polygon_officia_b324a3";"""

--- a/migrations/bt_search_bk/3_20251006144934_update.py
+++ b/migrations/bt_search_bk/3_20251006144934_update.py
@@ -1,0 +1,24 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        CREATE TABLE IF NOT EXISTS "collection" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "name" VARCHAR(100) NOT NULL UNIQUE,
+    "stac_url" VARCHAR(255) NOT NULL,
+    "updated_at" TIMESTAMPTZ NOT NULL
+);
+        CREATE TABLE IF NOT EXISTS "metric" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "short_name" VARCHAR(50) NOT NULL UNIQUE,
+    "name" VARCHAR(100) NOT NULL,
+    "collection_id" INT NOT NULL REFERENCES "collection" ("id") ON DELETE CASCADE,
+    CONSTRAINT "uid_metric_short_n_13c43e" UNIQUE ("short_name", "name", "collection_id")
+);"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        DROP TABLE IF EXISTS "collection";
+        DROP TABLE IF EXISTS "metric";"""

--- a/migrations/bt_search_bk/3_20251006171313_update.py
+++ b/migrations/bt_search_bk/3_20251006171313_update.py
@@ -1,0 +1,21 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """        
+        ALTER TABLE "polygon_metric" ADD "metric_id" INT NOT NULL;
+        ALTER TABLE "polygon_metric" DROP COLUMN "metric";
+        ALTER TABLE "polygon_metric_item" ADD "metric_id" INT NOT NULL;
+        ALTER TABLE "polygon_metric_item" DROP COLUMN "metric";
+        ALTER TABLE "polygon_metric" ADD CONSTRAINT "fk_polygon__metric_b9639c48" FOREIGN KEY ("metric_id") REFERENCES "metric" ("id") ON DELETE CASCADE;
+        ALTER TABLE "polygon_metric_item" ADD CONSTRAINT "fk_polygon__metric_684eb6e6" FOREIGN KEY ("metric_id") REFERENCES "metric" ("id") ON DELETE CASCADE;"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "polygon_metric_item" DROP CONSTRAINT "fk_polygon__metric_684eb6e6";
+        ALTER TABLE "polygon_metric" DROP CONSTRAINT "fk_polygon__metric_b9639c48";
+        ALTER TABLE "polygon_metric" ADD "metric" VARCHAR(100) NOT NULL;
+        ALTER TABLE "polygon_metric" DROP COLUMN "metric_id";
+        ALTER TABLE "polygon_metric_item" ADD "metric" VARCHAR(100) NOT NULL;
+        ALTER TABLE "polygon_metric_item" DROP COLUMN "metric_id";"""


### PR DESCRIPTION
## 🛠️ Cambios
- Agregadas nuevas tablas `metric` y `collection`.
- Se ha reemplazado la columna `metric` por `metric_id` de las tablas `polygon_metric` y `polygon_metric_item`. Ahora son llaves foráneas de la nueva tabla `metric`.
- Modificados endpoints de `values` y `layer` aplicando los cambios en la base de datos.
- Ñapa: Se ha habilitado la persistencia en el contenedor de `LocalStack`.
- Corrección en una migración anterior

## 📝 Tareas asociadas
Resuelve lib-324

## 🤔 Consideraciones
- No me fue posible aplicar todos los cambios en la base de datos con migraciones, por lo que es necesario recrear la base de datos desde cero. Les recomiendo hacerlo con estos comandos:

```sh
docker compose -f docker-compose-dev.yml down -v
aerich upgrade
python -m database.post_migrate
```