### PR TITLE
Logic for the layers for metrics of type AREA_TWO-COLLECTIONS

### DIFF
--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -8,7 +8,6 @@ from app.services.utils.raster import (
     get_one_raster_areas_by_classes,
     get_one_raster_average,
     get_two_raster_areas_by_classes,
-    get_two_raster_areas,
     get_two_raster_image,
 )
 from app.services.utils.stac import (
@@ -291,12 +290,12 @@ async def calculate_single_coll_layer(
     primary_collection: Collection,
     item_id: str,
     class_id: str,
-    _: Metric | None = None,
+    metric: Metric | None = None,
 ) -> str:
     """
     Get the layer for a metric that uses only one collection
     """
-    classes, values, colors, _ = await fetch_collection_metadata(
+    classes, values, colors, _categories = await fetch_collection_metadata(
         primary_collection
     )
 
@@ -330,7 +329,7 @@ async def calculate_two_colls_layer(
     """
     Get the layer for a metric that uses two collections.
     """
-    classes_map, values, colors = await fetch_collection_metadata(
+    classes_map, values, colors, _categories = await fetch_collection_metadata(
         primary_collection
     )
 

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -8,12 +8,15 @@ from app.services.utils.raster import (
     get_one_raster_areas_by_classes,
     get_one_raster_average,
     get_two_raster_areas_by_classes,
+    get_two_raster_areas,
+    get_two_raster_image,
 )
 from app.services.utils.stac import (
     get_item_resolution,
     get_item_index_by_resolution,
     get_items_asset_url,
     get_asset_href_by_item_id,
+    get_item_resolution_by_item_id,
 )
 from app.services.utils.stac import fetch_collection_metadata
 
@@ -139,6 +142,7 @@ async def get_or_create_polygon_metric_layer(
         primary_collection.collection,
         item_id,
         class_id,
+        metric_obj,
     )
     image_url = await upload_to_s3(
         image_data=img_base64,
@@ -288,6 +292,7 @@ async def calculate_single_coll_layer(
     primary_collection: Collection,
     item_id: str,
     class_id: str,
+    _: Metric | None = None,
 ) -> str:
     """
     Get the layer for a metric that uses only one collection
@@ -316,8 +321,71 @@ async def calculate_single_coll_layer(
     return image_base64
 
 
-def calculate_two_colls_layer():
-    pass
+async def calculate_two_colls_layer(
+    polygon: geometries.MultiPolygon,
+    primary_collection: Collection,
+    item_id: str,
+    class_id: str,
+    metric: Metric | None = None,
+) -> str:
+    """
+    Get the layer for a metric that uses two collections.
+    """
+    classes_map, values, colors = await fetch_collection_metadata(
+        primary_collection
+    )
+
+    if class_id not in classes_map:
+        raise MetadataError(
+            code=404,
+            log_msg=f"class_id {class_id} doesn't exist in metric",
+            usr_msg=f"class_id {class_id} doesn't exist in metric",
+        )
+
+    if metric is None:
+        raise ServerError(
+            code=500,
+            usr_msg="There was an internal error processing the request.",
+            e=Exception("Missing metric context for AREA_TWO-COLLECTIONS"),
+        )
+
+    secondary_metric_collection = next(
+        (mc for mc in metric.collections if not mc.is_primary), None
+    )
+    if secondary_metric_collection is None:
+        raise ServerError(
+            code=500,
+            usr_msg=f"There was an error calculating the metric {metric.name}.",
+            e=Exception("Secondary collection not found"),
+        )
+
+    await secondary_metric_collection.fetch_related("collection")
+    secondary_collection = secondary_metric_collection.collection
+
+    primary_raster_href = get_asset_href_by_item_id(
+        primary_collection.name, item_id
+    )
+    primary_res = get_item_resolution_by_item_id(
+        primary_collection.name, item_id
+    )
+
+    index_sec = get_item_index_by_resolution(
+        secondary_collection.name, primary_res
+    )
+    _, secondary_raster_href = get_items_asset_url(secondary_collection.name)[
+        index_sec
+    ]
+
+    image_base64 = get_two_raster_image(
+        raster_path=primary_raster_href,
+        mask_raster_path=secondary_raster_href,
+        polygon=polygon,
+        class_value=classes_map[class_id],
+        values=values,
+        colors=colors,
+    )
+
+    return image_base64
 
 
 def calculate_cat_single_coll_filtered_layer():

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -12,7 +12,6 @@ from app.services.utils.raster import (
     get_two_raster_image,
 )
 from app.services.utils.stac import (
-    get_item_resolution,
     get_item_index_by_resolution,
     get_items_asset_url,
     get_asset_href_by_item_id,
@@ -226,7 +225,7 @@ async def calculate_two_colls_values(
     secondary_collection = secondary_collection.collection
 
     id_pri, raster_pri_url = get_items_asset_url(primary_collection.name)[0]
-    resol_pri = get_item_resolution(primary_collection.name, 0)
+    resol_pri = get_item_resolution_by_item_id(primary_collection.name, id_pri)
 
     index_sec = get_item_index_by_resolution(
         secondary_collection.name, resol_pri

--- a/app/services/utils/raster.py
+++ b/app/services/utils/raster.py
@@ -339,3 +339,118 @@ def hex_to_rgba(hex_color: str) -> Tuple[int, int, int, int]:
         else:
             raise ValueError(f"Invalid hex color format: {hex_color}")
     raise ValueError(f"Hex color must start with '#': {hex_color}")
+
+
+def crop_two_rasters_by_polygon(
+    raster_path: str,
+    mask_raster_path: str,
+    polygon: geometries.MultiPolygon,
+) -> Tuple[
+    np.ndarray, np.ndarray, rasterio.Affine, ShapelyPolygon | MultiPolygon
+]:
+    polygon_geom = shape(polygon)
+
+    with (
+        rasterio.open(raster_path) as src,
+        rasterio.open(mask_raster_path) as mask_src,
+    ):
+        if src.crs != mask_src.crs:
+            raise ValueError(
+                "Raster coordinate reference systems do not match."
+            )
+        if src.res != mask_src.res:
+            raise ValueError("Raster resolutions do not match.")
+
+        minx, miny, maxx, maxy = polygon_geom.bounds
+        window = from_bounds(minx, miny, maxx, maxy, src.transform)
+        window_mask = from_bounds(minx, miny, maxx, maxy, mask_src.transform)
+
+        data = src.read(1, window=window)
+        mask_data = mask_src.read(1, window=window_mask)
+
+        data = np.where(np.isnan(data), 0, data)
+
+        mask_data = np.where(np.isnan(mask_data), 0, mask_data)
+
+        window_transform = src.window_transform(window)
+        return data, mask_data, window_transform, polygon_geom
+
+
+def get_two_raster_image(
+    raster_path: str,
+    mask_raster_path: str,
+    polygon: geometries.MultiPolygon,
+    class_value: int,
+    values: List[int],
+    colors: List[str],
+) -> str:
+    Image.MAX_IMAGE_PIXELS = None
+
+    colormap: Dict[int, Tuple[int, int, int, int]] = {
+        value: hex_to_rgba(color) for value, color in zip(values, colors)
+    }
+    if class_value not in colormap:
+        raise MetadataError(
+            code=501,
+            usr_msg="There was an internal error processing the request",
+            log_msg=f"Class {class_value} not found in the colors metadata.",
+        )
+
+    try:
+        data, mask_data, window_transform, polygon_geom = (
+            crop_two_rasters_by_polygon(
+                raster_path=raster_path,
+                mask_raster_path=mask_raster_path,
+                polygon=polygon,
+            )
+        )
+
+        polygon_mask = rasterize(
+            [polygon_geom],
+            out_shape=data.shape,
+            transform=window_transform,
+            fill=0,
+            default_value=1,
+            dtype=np.uint8,
+        )
+
+        mask_binary = mask_data > 0
+        combined_mask = (polygon_mask == 1) & mask_binary
+        masked_data = np.where(combined_mask, data, np.nan)
+
+        if len(masked_data) == 0 or np.all(masked_data != class_value):
+            raise NotFoundError(
+                usr_msg="No data available for the selected class.",
+                log_msg=(
+                    f"No data generated for class value {class_value} "
+                    "after applying polygon + mask raster intersection."
+                ),
+            )
+
+        h, w = masked_data.shape
+        rgba = np.zeros((h, w, 4), dtype=np.uint8)
+        rgba[masked_data == class_value] = colormap[class_value]
+
+        pil_image = Image.fromarray(rgba, mode="RGBA")
+        img_buffer = io.BytesIO()
+        pil_image.save(img_buffer, format="PNG")
+        img_buffer.seek(0)
+        img_base64 = base64.b64encode(img_buffer.getvalue()).decode("utf-8")
+
+        del data, mask_data, polygon_mask, mask_binary, combined_mask
+        del masked_data, rgba, img_buffer, pil_image
+    except NotFoundError:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Unexpected error rendering class value {class_value}: {str(e)}"
+        )
+        raise ServerError(
+            code=500,
+            usr_msg="There was an error processing the requested class.",
+            e=e,
+        )
+    finally:
+        gc.collect()
+
+    return img_base64

--- a/app/services/utils/raster.py
+++ b/app/services/utils/raster.py
@@ -6,7 +6,7 @@ import numpy as np
 from typing import Dict, List, Optional, Tuple
 from shapely import box
 from shapely.ops import transform as shapely_transform
-from shapely.geometry import shape, Polygon as ShapelyPolygon
+from shapely.geometry import shape, Polygon as ShapelyPolygon, MultiPolygon
 
 import rasterio
 from rasterio.crs import CRS

--- a/app/services/utils/raster.py
+++ b/app/services/utils/raster.py
@@ -348,7 +348,17 @@ def crop_two_rasters_by_polygon(
 ) -> Tuple[
     np.ndarray, np.ndarray, rasterio.Affine, ShapelyPolygon | MultiPolygon
 ]:
-    polygon_geom = shape(polygon)
+    polygon_geom_raw = shape(polygon)
+    if isinstance(polygon_geom_raw, (ShapelyPolygon, MultiPolygon)):
+        polygon_geom = polygon_geom_raw
+    else:
+        raise UnprocessableError(
+            code=422,
+            usr_msg="Invalid polygon geometry.",
+            e=Exception(
+                f"Expected Polygon or MultiPolygon, got {type(polygon_geom_raw)}"
+            ),
+        )
 
     with (
         rasterio.open(raster_path) as src,

--- a/app/services/utils/stac.py
+++ b/app/services/utils/stac.py
@@ -180,58 +180,6 @@ def get_asset_href_by_item_id(collection_id: str, item_id: str) -> str:
     return asset_href
 
 
-def get_item_resolution(collection_id: str, index_item: int) -> float:
-    """
-    Returns the spatial resolution of the item at the given index in the collection.
-    """
-    items_url = get_collection_items_url(collection_id)
-    response = None
-
-    try:
-        response = requests.get(items_url)
-        response.raise_for_status()
-    except Exception as e:
-        if response is not None and response.status_code == 404:
-            raise NotFoundError(
-                usr_msg=f"{collection_id} data is incomplete",
-                log_msg=f"Collection items not found at URL: {items_url}",
-                e=e,
-            )
-        else:
-            raise ServerError(
-                code=500,
-                usr_msg=f"There was an error retrieving {collection_id} data",
-                e=e,
-            )
-
-    items_data = response.json()
-    if not items_data.get("features"):
-        raise NotFoundError(
-            usr_msg=f"{collection_id} data is incomplete",
-            log_msg=f"Collection items url exist but it has no features, url: {items_url}",
-        )
-
-    if index_item < 0 or index_item >= len(items_data["features"]):
-        raise NotFoundError(
-            usr_msg="Requested item index is out of range",
-            log_msg=(
-                f"Index {index_item} out of range for collection "
-                f"{collection_id}. Items available: {len(features)}"
-            ),
-        )
-    item = items_data.get("features")[index_item]
-    for asset in item.get("assets", {}).values():
-        for band in asset.get("raster:bands", []):
-            resolution = band.get("spatial_resolution")
-            if resolution is not None:
-                return resolution
-
-    raise NotFoundError(
-        usr_msg="Item has no spatial resolution information",
-        log_msg=f"Item {index_item} in collection {collection_id} has no raster bands with spatial_resolution",
-    )
-
-
 def get_item_index_by_resolution(collection_id: str, resol_obj: float) -> int:
     """
     Returns the index of the item in the collection that has the closest spatial resolution to a given value.

--- a/app/services/utils/stac.py
+++ b/app/services/utils/stac.py
@@ -291,3 +291,44 @@ def get_item_index_by_resolution(collection_id: str, resol_obj: float) -> int:
         key=lambda x: abs(x[1] - resol_obj),
     )
     return closest_item_index
+
+
+def get_item_resolution_by_item_id(collection_id: str, item_id: str) -> float:
+    """
+    Returns the spatial resolution of a specific item in the collection.
+    """
+    item_id_url = url.build_url(
+        settings.stac_url, f"/collections/{collection_id}/items/{item_id}"
+    )
+    response = None
+
+    try:
+        response = requests.get(item_id_url)
+        response.raise_for_status()
+    except Exception as e:
+        if response is not None and response.status_code == 404:
+            raise NotFoundError(
+                usr_msg=f"item {item_id} not found in {collection_id}",
+                log_msg=f"{item_id_url} not found",
+                e=e,
+            )
+        raise ServerError(
+            code=500,
+            usr_msg=f"There was an error retrieving {collection_id} data",
+            e=e,
+        )
+
+    item_data = response.json()
+    for asset in item_data.get("assets", {}).values():
+        for band in asset.get("raster:bands", []):
+            resolution = band.get("spatial_resolution")
+            if resolution is not None:
+                return resolution
+
+    raise NotFoundError(
+        usr_msg="Item has no spatial resolution information",
+        log_msg=(
+            f"Item {item_id} in collection {collection_id} has no raster "
+            "bands with spatial_resolution"
+        ),
+    )


### PR DESCRIPTION
## 🛠️ Changes

- Enable the generation of layers for metrics that combine two collections
- Obtain the resolution of the selected item in the primary collection and chooses the equivalent raster in the secondary collection
- Generate the final raster for two collections metrics type

## 📝 Associated issues
- Solves LIB-546

## 🤔 Considerations

## ✅ Checks
