### PR TITLE
logic to endpoint values currentRecordsGaps_average

### DIFF
--- a/app/routes/schemas/MetricResponse.py
+++ b/app/routes/schemas/MetricResponse.py
@@ -48,9 +48,9 @@ class CurrentHFResponse(BaseMetricResult):
     Muy_Alta: float = Field(alias="Muy Alta")
 
 
-class CurrentHFAverageResponse(BaseMetricResult):
+class CurrentAverageResponse(BaseMetricResult):
     """
-    Response model for Human Footprint average in a given year.
+    Response model the average of a cropped collection in a given year.
     """
 
     average: float

--- a/app/utils/metrics_config.py
+++ b/app/utils/metrics_config.py
@@ -57,6 +57,7 @@ class MetricsConfigType(TypedDict):
     protectedAreas_tropicalDryForest: MetricConfig
     protectedAreas_wetland: MetricConfig
     recordGaps: MetricConfig
+    currentRecordsGaps_average: MetricConfig
 
 
 # This config contains everything related to FastAPI and Pydantic validations

--- a/app/utils/metrics_config.py
+++ b/app/utils/metrics_config.py
@@ -5,7 +5,7 @@ from app.routes.schemas.MetricResponse import (
     LossPersistenceListResponse,
     CoverageResponse,
     CurrentHFResponse,
-    CurrentHFAverageResponse,
+    CurrentAverageResponse,
     LossPersistenceSingleResponse,
     ParamoResponse,
     TropicalDryForestResponse,
@@ -21,7 +21,7 @@ MetricResponse = Union[
     LossPersistenceListResponse,
     CoverageResponse,
     CurrentHFResponse,
-    CurrentHFAverageResponse,
+    CurrentAverageResponse,
     ParamoResponse,
     TropicalDryForestResponse,
     WetlandResponse,
@@ -118,8 +118,8 @@ METRICS_CONFIG: MetricsConfigType = {
         "description": "Categorized human footprint index",
     },
     "currentHF_average": {
-        "model": CurrentHFAverageResponse,
-        "example": CurrentHFAverageResponse(
+        "model": CurrentAverageResponse,
+        "example": CurrentAverageResponse(
             id="2018",
             average=12.34,
         ),
@@ -330,8 +330,8 @@ METRICS_CONFIG: MetricsConfigType = {
         "description": "Record gaps frequency",
     },
     "currentRecordsGaps_average": {
-        "model": CurrentHFAverageResponse,
-        "example": CurrentHFAverageResponse(
+        "model": CurrentAverageResponse,
+        "example": CurrentAverageResponse(
             id="2018",
             average=0.87,
         ),

--- a/app/utils/metrics_config.py
+++ b/app/utils/metrics_config.py
@@ -328,6 +328,14 @@ METRICS_CONFIG: MetricsConfigType = {
         ),
         "description": "Record gaps frequency",
     },
+    "currentRecordsGaps_average": {
+        "model": CurrentHFAverageResponse,
+        "example": CurrentHFAverageResponse(
+            id="2018",
+            average=0.87,
+        ),
+        "description": "Average human footprint index",
+    },
     # "timelineHF": {},
     # TODO: implementar estas:
     # "timelineHF": {},

--- a/database/seed_collections_and_metrics.py
+++ b/database/seed_collections_and_metrics.py
@@ -166,7 +166,6 @@ class MetricEnum(Enum):
         OperationEnum.AVERAGE_SINGLE_COLLECTION,
         CollectionEnum.INDICE_VACIOS_INFORMACION,
     )
-    
 
     def __init__(
         self,

--- a/database/seed_collections_and_metrics.py
+++ b/database/seed_collections_and_metrics.py
@@ -161,6 +161,12 @@ class MetricEnum(Enum):
         OperationEnum.FREQUENCY_SINGLE_COLLECTION,
         CollectionEnum.INDICE_VACIOS_INFORMACION,
     )
+    CURRENRECORDSGAPS_AVERAGE = (
+        "currentRecordsGaps_average",
+        OperationEnum.AVERAGE_SINGLE_COLLECTION,
+        CollectionEnum.INDICE_VACIOS_INFORMACION,
+    )
+    
 
     def __init__(
         self,


### PR DESCRIPTION
> Remove all lines starting with > before creatign the PR
## 🛠️ Changes
logic to create the endpoint values currentRecordsGaps_average
## 📝 Associated issues
Solves LIB-699

## 🤔 Considerations
Como es la media de un polígono y ya contabamos con las funciones y respuestas para esta métrica reutilicé esta metric response "CurrentHFAverageResponse" sin embargo su nombre indica que es para a huella humana. me gustaría saber qué opina @erikasv de esto. si le cambiamos el nombre a esa respuesta para que sea más genérica para todos los endpoints de promedio de un recorte o cómo considera que es la mejor manera de proceder.

Apply new migrations to the database

This PR is based on the branch amontoya/LIB-698
## ✅ Checks
> List of additional checks for a development. For example, update the docs.
